### PR TITLE
Improve reference to `ManagedBass.Midi`

### DIFF
--- a/DrumGame/DrumGame-Game/DrumGame.Game.csproj
+++ b/DrumGame/DrumGame-Game/DrumGame.Game.csproj
@@ -17,10 +17,20 @@
     <PackageReference Include="glTF2Loader" Version="1.1.3-alpha" />
     <PackageReference Include="NAudio.Asio" Version="2.1.0" />
     <PackageReference Include="ManagedBass.Midi" Version="3.1.0" />
+    <!--
+    ppy.osu.Framework uses a custom fork of ManagedBass (ppy.ManagedBass) which does have a corresponding
+    ManagedBass.Midi package. This causes a conflict when trying to use ManagedBass.Midi in the same project as
+    ppy.osu.Framework because ManagedBass.Midi requires types from the original ManagedBass package, not the
+    ppy.ManagedBass package.
+
+    To resolve this, we add an explicit reference to the ManagedBass package and alias it to "OriginalManagedBass". By
+    using an alias, we can use the aliased package in the code with ManagedBass.Midi, and the osu framework can continue
+    to use the ppy.ManagedBass package.
+    -->
+    <PackageReference Include="ManagedBass" Version="3.1.1" Aliases="OriginalManagedBass" />
     
     <!-- <PackageReference Include="NAudio" Version="2.1.0" /> -->
     <!-- <ProjectReference Include="..\..\FFMediaToolkit\FFMediaToolkit\FFMediaToolkit.csproj" /> -->
-    <ProjectReference Include="..\..\osu-framework\osu.Framework\osu.Framework.csproj" />
-    <!-- <PackageReference Include="ppy.osu.Framework" Version="2022.1110.0" /> -->
+     <PackageReference Include="ppy.osu.Framework" Version="2024.523.0" />
   </ItemGroup>
 </Project>

--- a/DrumGame/DrumGame-Game/Media/SoundFont.cs
+++ b/DrumGame/DrumGame-Game/Media/SoundFont.cs
@@ -1,3 +1,5 @@
+extern alias OriginalManagedBass;
+
 using System;
 using System.Diagnostics;
 using DrumGame.Game.Beatmaps.Scoring;
@@ -10,6 +12,8 @@ using ManagedBass.Midi;
 using osu.Framework.Bindables;
 using osu.Framework.Development;
 using osu.Framework.Logging;
+
+using BassFlags = OriginalManagedBass::ManagedBass.BassFlags;
 
 namespace DrumGame.Game.Media;
 

--- a/DrumGame/DrumGame-Game/Media/SoundFontRenderer.cs
+++ b/DrumGame/DrumGame-Game/Media/SoundFontRenderer.cs
@@ -1,3 +1,5 @@
+extern alias OriginalManagedBass;
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -12,6 +14,8 @@ using DrumGame.Game.Utils;
 using ManagedBass;
 using ManagedBass.Midi;
 using osu.Framework.Logging;
+
+using BassFlags = OriginalManagedBass::ManagedBass.BassFlags;
 
 namespace DrumGame.Game.Media;
 

--- a/DrumGame/DrumGame.sln
+++ b/DrumGame/DrumGame.sln
@@ -14,8 +14,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		DrumGame.sln.DotSettings = DrumGame.sln.DotSettings
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework", "..\osu-framework\osu.Framework\osu.Framework.csproj", "{0AA5E706-96F7-4908-87B0-18122D5DCD8C}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,10 +44,6 @@ Global
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|iPhone.Build.0 = Release|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{0AA5E706-96F7-4908-87B0-18122D5DCD8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0AA5E706-96F7-4908-87B0-18122D5DCD8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0AA5E706-96F7-4908-87B0-18122D5DCD8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0AA5E706-96F7-4908-87B0-18122D5DCD8C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fixes #4

Improves the reference to `ManagedBass.Midi` to make it easier to run the project from source.

The issue was that `ppy.osu.Framework` uses a custom fork of `ManagedBass` (`ppy.ManagedBass`) which does have a corresponding `ManagedBass.Midi` package. This causes a conflict when trying to use `ManagedBass.Midi` in the same project as `ppy.osu.Framework` because `ManagedBass.Midi` requires types from the original `ManagedBass` package, not the `ppy.ManagedBass` package.

The original workaround was to clone [the repository](https://github.com/ppy/osu-framework) of the `ppy.osu.Framework` package, swap the reference to `ppy.ManagedBass` to `ManagedBass` (located [here](https://github.com/ppy/osu-framework/blob/451f8b2d614c906733dd74a94c04e5e044cbf3c2/osu.Framework/osu.Framework.csproj#L27C5-L27C73)), and use this local version of the framework when building the game. This is not ideal because it requires cloning the entire osu framework repository, modifying the framework code, and adding the osu framework project to the game's solution.

Due to the way that transitive dependencies are handled, there are no easy ways to resolve this issue. On top of that, the names of the types or namespaces were not changed during the forking process so there are conflicts everywhere (a type with the same name will be present in the exact same namespace in two assemblies). Even the concept of assembly binding redirects does not work in this case because the new version (`ppy.ManagedBass`) has a different public key token and name than the original version (`ManagedBass`).

To resolve this, an explicit reference to the `ManagedBass` package was added and it was aliased to `OriginalManagedBass`. By using an alias, `ManagedBass` in the code with `ManagedBass.Midi`, and the osu framework can continue to use the `ppy.ManagedBass` package.

This is still not ideal because the code that uses `ManagedBass` will need to use the alias `OriginalManagedBass` to access the types from the original `ManagedBass` package. However, this is a much simpler solution than the previous workaround.